### PR TITLE
chore(api): Switch API runtime to Bun for Render; bind 0.0.0.0; Prisma engines for OpenSSL 3; Redis TS fixes

### DIFF
--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -3,6 +3,8 @@
 
 generator client {
   provider = "prisma-client-js"
+  // Explicit binary targets to ensure compatible engines on Render (OpenSSL 3.0)
+  binaryTargets = ["native", "linux-arm64-openssl-3.0.x", "debian-openssl-3.0.x"]
   previewFeatures = ["postgresqlExtensions", "fullTextSearch", "fullTextIndex"]
 }
 

--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -21,20 +21,31 @@ RUN ls -la /app/services/api/
 RUN ls -la /app/services/api/dist/ || echo "dist directory not found"
 
 # --- Runtime ---
-FROM node:20-slim
+FROM oven/bun:1
+
+# Set working directory for the runtime image
 WORKDIR /app
 
-# Prisma requires OpenSSL at runtime in Debian-based images
+# Prisma requires OpenSSL at runtime in Debian-based images (bun image is debian-based)
 RUN apt-get update -y && apt-get install -y openssl && rm -rf /var/lib/apt/lists/*
 
-# Copy production artifacts and dependencies
+# Copy production artifacts from the builder
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/packages ./packages
 COPY --from=builder /app/services/api/package.json ./services/api/package.json
 COPY --from=builder /app/services/api/dist ./services/api/dist
 
+# Environment configuration
 ENV NODE_ENV=production
-USER node
+
+# Switch to non-root bun user provided by the image
+USER bun
+
+# Move into the API service directory for execution
 WORKDIR /app/services/api
+
+# Expose application port
 EXPOSE 3000
-CMD ["node", "dist/index.js"]
+
+# Start the Elysia server with Bun
+CMD ["bun", "dist/index.js"]

--- a/services/api/src/index.ts
+++ b/services/api/src/index.ts
@@ -134,7 +134,7 @@ async function init() {
   }
 
   // Start HTTP server
-  app.listen(PORT);
+  app.listen({ port: PORT, hostname: '0.0.0.0' });
   console.log(`🚀 API server running at http://localhost:${PORT}`);
 }
 

--- a/services/worker/src/index.ts
+++ b/services/worker/src/index.ts
@@ -1,6 +1,6 @@
 import { getJob, updateJob, prisma } from '@ifi/db';
 import { JobStatus } from '@ifi/shared';
-import Redis from 'ioredis';
+import { Redis } from 'ioredis';
 
 // Optional Redis client
 let redisClient: Redis | null = null;
@@ -12,16 +12,17 @@ if (process.env.REDIS_URL) {
     console.log('✅ Connected to Redis');
     
     // Subscribe to the jobs channel
-    redisClient.subscribe('jobs', (err) => {
-      if (err) {
-        console.error('❌ Failed to subscribe to Redis channel:', err);
-      } else {
+    redisClient
+      .subscribe('jobs')
+      .then(() => {
         console.log('✅ Subscribed to jobs channel');
-      }
-    });
+      })
+      .catch((err: Error) => {
+        console.error('❌ Failed to subscribe to Redis channel:', err);
+      });
     
     // Listen for messages
-    redisClient.on('message', (channel, message) => {
+    redisClient.on('message', (channel: string, message: string) => {
       if (channel === 'jobs') {
         console.log('📨 Received job notification:', message);
         // We'll still rely on polling for job processing
@@ -29,7 +30,7 @@ if (process.env.REDIS_URL) {
     });
     
     // Handle Redis errors
-    redisClient.on('error', (err) => {
+    redisClient.on('error', (err: Error) => {
       console.error('❌ Redis error:', err);
     });
   } catch (error) {


### PR DESCRIPTION
Droid-assisted PR.

Summary
- Switch API runtime to Bun (oven/bun:1) to ensure Elysia compatibility on Render.
- Explicitly bind API to 0.0.0.0 for Render health checks.
- Add OpenSSL 3.0 compatible Prisma engines (debian + linux-arm64) in schema.prisma.
- Keep Node builder; Yarn workspaces; Prisma generate in builder.
- Install OpenSSL in runtime image for Prisma.
- Worker: fix ioredis types for ESM/NodeNext and promise-based subscribe.

Files changed
- services/api/Dockerfile
- services/api/src/index.ts
- packages/db/prisma/schema.prisma
- services/worker/src/index.ts

Validation
- yarn build / typecheck: OK locally
- Docker build for API: OK; server starts under Bun runtime
- Prisma client generation: OK with new binaryTargets

Notes
- API contract unchanged: /api/health, POST /api/chat, GET /api/jobs/:id
- Long-running work remains in worker
- Render blueprint unchanged (render.yaml)

Once merged, Render should build/deploy cleanly as a Docker web service.

---
**Factory Session:** https://app.factory.ai/sessions/Tb4v9EtVEdiO3Z8rO92z (created by sanoziec@gmail.com)